### PR TITLE
Clarify Truffle console parameters

### DIFF
--- a/docs/docs/building.md
+++ b/docs/docs/building.md
@@ -104,7 +104,7 @@ _Voilà!_ You have deployed and upgraded an application using ZeppelinOS. The ad
 To try the upgraded feature we just added, run:
 ```sh
 npx truffle console --network=local
-truffle(local)> myContract = MyContract.at(<your-instance-address>)
+truffle(local)> myContract = MyContract.at("<your-instance-address>")
 truffle(local)> myContract.increment()
 truffle(local)> myContract.x()
 43


### PR DESCRIPTION
Truffle's `at()` function takes in a string. I was copying and pasting the address from the terminal and was unsure why it wasn't working. Quotes should be added to clarify this.